### PR TITLE
Added support for `lockDistance` option

### DIFF
--- a/reticulum.js
+++ b/reticulum.js
@@ -7,7 +7,7 @@
 
 var Reticulum = (function () {
     var INTERSECTED = null;
-    
+
     var collisionList = [];
     var raycaster;
     var vector;
@@ -19,28 +19,29 @@ var Reticulum = (function () {
     var cameraViewProjectionMatrix;
 
     var parentContainer
-    
+
     //Settings from user
     var settings = {
         camera:             null, //Required
         proximity:          false,
-        isClickEnabled:     true
+        isClickEnabled:     true,
+        lockDistance:       false
     };
-    
+
     //Utilities
     var utilities = {
         clampBottom: function ( x, a ) {
             return x < a ? a : x;
         }
-    } 
-    
+    }
+
     //Vibrate
     var vibrate = navigator.vibrate ? navigator.vibrate.bind(navigator) : function(){};
-    
+
     //Fuse
     fuse.initiate = function( options ) {
         var parameters = options || {};
-        
+
         this.visible        = parameters.visible            !== false; //default to true;
         this.globalDuration = parameters.duration           ||  2.5;
         this.vibratePattern = parameters.vibrate            ||  100;
@@ -53,89 +54,88 @@ var Reticulum = (function () {
         this.thetaStart     = Math.PI/2;
         this.duration       = this.globalDuration;
 
-        
         //var geometry = new THREE.CircleGeometry( reticle.outerRadiusTo, 32, Math.PI/2, 0 );
         var geometry = new THREE.RingGeometry( this.innerRadius, this.outerRadius, this.thetaSegments, this.phiSegments, this.thetaStart, 0 );
-       
+
         //Make Mesh
-        this.mesh = new THREE.Mesh( geometry, new THREE.MeshBasicMaterial( { 
+        this.mesh = new THREE.Mesh( geometry, new THREE.MeshBasicMaterial( {
             color: this.color,
             side: THREE.BackSide,
             fog: false
             //depthWrite: false,
             //depthTest: false
         }));
-        
+
         //Set mesh visibility
         this.mesh.visible = this.visible;
-        
+
         //Change position and rotation of fuse
         this.mesh.position.z = 0.0001; // Keep in front of reticle
         this.mesh.rotation.y = 180*(Math.PI/180); //Make it clockwise
-        
+
         //Add to reticle
         //reticle.mesh.add( this.mesh );
         parentContainer.add( this.mesh );
         //geometry.dispose();
     };
-    
+
     fuse.out = function() {
         this.active = false;
         this.mesh.visible = false;
-        this.update(0);   
+        this.update(0);
     }
-    
+
     fuse.over = function(duration, visible) {
         this.duration = duration || this.globalDuration;
         this.active = true;
-        this.update(0); 
+        this.update(0);
         this.mesh.visible = visible || this.visible;
     }
-    
+
     fuse.update = function(elapsed) {
-        
+
         if(!this.active) return;
-        
+
         //--RING
         var gazedTime = elapsed/this.duration;
         var thetaLength = gazedTime * (Math.PI*2);
-        
+
         var vertices = this.mesh.geometry.vertices;
         var radius = this.innerRadius;
         var radiusStep = ( ( this.outerRadius - this.innerRadius ) / this.phiSegments );
         var count = 0;
-        
-        for ( var i = 0; i < this.phiSegments + 1; i ++ ) { 
-        
+
+        for ( var i = 0; i < this.phiSegments + 1; i ++ ) {
+
             for ( var o = 0; o < this.thetaSegments + 1; o++ ) {
-            
+
                 var vertex = vertices[ count ];
                 var segment = this.thetaStart + o / this.thetaSegments * thetaLength;
-                vertex.x = radius * Math.cos( segment ); 
-                vertex.y = radius * Math.sin( segment ); 
+                vertex.x = radius * Math.cos( segment );
+                vertex.y = radius * Math.sin( segment );
                 count++;
             }
-            radius += radiusStep;  
+            radius += radiusStep;
         }
-        
+
         this.mesh.geometry.verticesNeedUpdate = true;
-        
+
         //Disable fuse if reached 100%
         if(gazedTime >= 1) {
             this.active = false;
         }
         //--RING EOF
 
-        
+
     }
-    
+
     //Reticle
     reticle.initiate = function( options ) {
         var parameters = options || {};
 
         parameters.hover = parameters.hover || {};
         parameters.click = parameters.click || {};
-        
+
         this.active             = true;
         this.visible            = parameters.visible            !== false; //default to true;
         this.restPoint          = parameters.restPoint          || settings.camera.far-10.0;
@@ -144,6 +144,7 @@ var Reticulum = (function () {
         this.outerRadius        = parameters.outerRadius        || 0.003;
         this.worldPosition      = new THREE.Vector3();
         this.ignoreInvisible    = parameters.ignoreInvisible    !== false; //default to true;
+
         //Hover
         this.innerRadiusTo      = parameters.hover.innerRadius  || 0.02;
         this.outerRadiusTo      = parameters.hover.outerRadius  || 0.024;
@@ -151,26 +152,26 @@ var Reticulum = (function () {
         this.vibrateHover       = parameters.hover.vibrate      || 50;
         this.hit                = false;
         //Click
-        this.vibrateClick       = parameters.click.vibrate      || 50; 
+        this.vibrateClick       = parameters.click.vibrate      || 50;
         //Animation options
         this.speed              = parameters.hover.speed        || 5;
         this.moveSpeed          = 0;
-        
+
         //Colors
         this.globalColor = new THREE.Color( this.globalColor );
         this.color = this.globalColor.clone();
         this.globalColorTo = new THREE.Color( this.globalColorTo );
         this.colorTo = this.globalColorTo.clone();
-        
+
         //Geometry
         var geometry = new THREE.RingGeometry( this.innerRadius, this.outerRadius, 32, 3, 0, Math.PI * 2 );
         var geometryScale = new THREE.RingGeometry( this.innerRadiusTo, this.outerRadiusTo, 32, 3, 0, Math.PI * 2 );
-        
+
         //Add Morph Targets for scale animation
         geometry.morphTargets.push( { name: "target1", vertices: geometryScale.vertices } );
-        
+
         //Make Mesh
-        this.mesh = new THREE.Mesh( geometry, new THREE.MeshBasicMaterial( { 
+        this.mesh = new THREE.Mesh( geometry, new THREE.MeshBasicMaterial( {
             color: this.color,
             morphTargets: true,
             fog: false
@@ -178,16 +179,16 @@ var Reticulum = (function () {
             //depthTest: false
         }));
         this.mesh.visible = this.visible;
-        
+
         //set depth and scale
         this.setDepthAndScale();
-        
+
         //Add to camera
         //settings.camera.add( this.mesh );
         parentContainer.add( this.mesh );
-        
+
     };
-    
+
     //Sets the depth and scale of the reticle - reduces eyestrain and depth issues 
     reticle.setDepthAndScale = function( depth ) {
         //var crosshair = this.mesh;
@@ -197,22 +198,22 @@ var Reticulum = (function () {
         //Force reticle to appear the same size - scale
         //http://answers.unity3d.com/questions/419342/make-gameobject-size-always-be-the-same.html
         var scale = Math.abs( cameraZ - z ) - Math.abs( cameraZ );
-        
+
         //Set Depth
         crosshair.position.x = 0;
         crosshair.position.y = 0;
         crosshair.position.z = utilities.clampBottom( z, settings.camera.near+0.1 ) * -1;
-        
+
         //Set Scale
         crosshair.scale.set( scale, scale, scale );
     };
-    
+
     reticle.update = function(delta) {
         //If not active
         if(!this.active) return;
-        
+
         var accel = delta * this.speed;
-        
+
         if( this.hit ) {
             this.moveSpeed += accel;
             this.moveSpeed = Math.min(this.moveSpeed, 1);
@@ -231,13 +232,14 @@ var Reticulum = (function () {
     var initiate = function (camera, options) {
         //Update Settings:
         options = options || {};
-        
+
         settings.camera = camera; //required
         settings.proximity = options.proximity || settings.proximity;
+        settings.lockDistance = options.lockDistance || settings.lockDistance;
         settings.isClickEnabled = options.clickevents || settings.isClickEnabled;
         options.reticle = options.reticle || {};
         options.fuse = options.fuse || {};
-        
+
         //Raycaster Setup
         raycaster = new THREE.Raycaster();
         vector = new THREE.Vector2(0, 0);
@@ -258,27 +260,27 @@ var Reticulum = (function () {
             frustum = new THREE.Frustum();
             cameraViewProjectionMatrix = new THREE.Matrix4();
         }
-        
+
         //Enable Click / Tap Events
         if( settings.isClickEnabled ) {
             document.body.addEventListener('touchend', touchClickHandler, false);
             document.body.addEventListener('click', touchClickHandler, false);
         }
-        
+
         //Clock Setup
         clock = new THREE.Clock(true);
-        
+
         //Initiate Reticle
         reticle.initiate(options.reticle);
-        
+
         //Initiate Fuse
         fuse.initiate(options.fuse);
     };
-    
+
     var proximity = function() {
         var camera = settings.camera;
         var showReticle = false;
-        
+
         //Use frustum to see if any targetable object is visible
         //http://stackoverflow.com/questions/17624021/determine-if-a-mesh-is-visible-on-the-viewport-according-to-current-camera
         camera.updateMatrixWorld();
@@ -286,7 +288,7 @@ var Reticulum = (function () {
         cameraViewProjectionMatrix.multiplyMatrices( camera.projectionMatrix, camera.matrixWorldInverse );
 
         frustum.setFromMatrix( cameraViewProjectionMatrix );
-        
+
 
         for( var i =0, l=collisionList.length; i<l; i++) {
 
@@ -295,7 +297,7 @@ var Reticulum = (function () {
             if(!newObj.reticulumData.gazeable) {
                 continue;
             }
-            
+
             if( reticle.ignoreInvisible && !newObj.visible) {
                 continue;
             }
@@ -307,7 +309,7 @@ var Reticulum = (function () {
 
         }
         reticle.mesh.visible = showReticle;
-        
+
     };
 
     var detectHit = function() {
@@ -327,7 +329,7 @@ var Reticulum = (function () {
         if (intersectsCount) {
 
             var newObj;
-            
+
             //Check if what we are hitting can be used
             for( var i =0, l=intersectsCount; i<l; i++) {
                 newObj = intersects[ i ].object;
@@ -347,7 +349,7 @@ var Reticulum = (function () {
                 //No issues let use this one
                 break;
             }
-            
+
             //There is no valid object
             if (newObj === null) return;
 
@@ -362,8 +364,8 @@ var Reticulum = (function () {
                 INTERSECTED = newObj;
                 //Is the object gazeable?
                 //if (INTERSECTED.gazeable) {
-                    //Yes
-                    gazeOver(INTERSECTED);
+                //Yes
+                gazeOver(INTERSECTED);
                 //}
             } else {
                 //Ok it looks like we are in love
@@ -373,16 +375,16 @@ var Reticulum = (function () {
         } else {
             //Is the object gazeable?
             //if (INTERSECTED.gazeable) {
-                if (INTERSECTED) {
-                    //GAZE OUT
-                    gazeOut(INTERSECTED);
-                }
+            if (INTERSECTED) {
+                //GAZE OUT
+                gazeOut(INTERSECTED);
+            }
             //}
             INTERSECTED = null;
 
         }
     };
-    
+
     var setColor = function(threeObject, color) {
         threeObject.material.color.setHex( color );
     };
@@ -390,12 +392,12 @@ var Reticulum = (function () {
     var gazeOut = function(threeObject) {
         threeObject.userData.hitTime = 0;
         //if(threeObject.fuse) {
-            fuse.out();    
+        fuse.out();
         //}
-        
+
         reticle.hit = false;
         reticle.setDepthAndScale();
-        
+
         if ( threeObject.onGazeOut != null ) {
             threeObject.onGazeOut();
         }
@@ -404,15 +406,15 @@ var Reticulum = (function () {
     var gazeOver = function(threeObject) {
         var threeObjectData = threeObject.reticulumData;
         reticle.colorTo = threeObjectData.reticleHoverColor || reticle.globalColorTo;
-        
+
         //Fuse
         fuse.over(threeObjectData.fuseDuration, threeObjectData.fuseVisible);
         if(threeObjectData.fuseColor) {
-          setColor(fuse.mesh, threeObjectData.fuseColor);    
+            setColor(fuse.mesh, threeObjectData.fuseColor);
         }
-        
+
         threeObject.userData.hitTime = clock.getElapsedTime();
-        
+
         //Reticle
         //Vibrate
         vibrate( reticle.vibrateHover );
@@ -426,16 +428,23 @@ var Reticulum = (function () {
         var distance;
         var elapsed = clock.getElapsedTime();
         var gazeTime = elapsed - threeObject.userData.hitTime;
-         //There has to be a better  way...
-         //Keep updating distance while user is focused on target
+        //There has to be a better  way...
+        //Keep updating distance while user is focused on target
         if( reticle.active ) {
-            reticle.worldPosition.setFromMatrixPosition( threeObject.matrixWorld ); 
-            distance = settings.camera.position.distanceTo( reticle.worldPosition );
-            distance -= threeObject.geometry.boundingSphere.radius;
+
+            if(!settings.lockDistance){
+                reticle.worldPosition.setFromMatrixPosition( threeObject.matrixWorld );
+                distance = settings.camera.position.distanceTo( reticle.worldPosition );
+                distance -= threeObject.geometry.boundingSphere.radius;
+            }
+
             reticle.hit = true;
-            reticle.setDepthAndScale( distance );
+
+            if(!settings.lockDistance) {
+                reticle.setDepthAndScale(distance);
+            }
         }
-        
+
         //Fuse
         if( gazeTime >= fuse.duration && !fuse.active ) {
             //Vibrate
@@ -447,10 +456,10 @@ var Reticulum = (function () {
             //Reset the clock
             threeObject.userData.hitTime = elapsed;
         } else {
-            fuse.update(gazeTime); 
+            fuse.update(gazeTime);
         }
     };
-    
+
     var gazeClick = function( threeObject ) {
         var clickCancelFuse = threeObject.reticulumData.clickCancelFuse != null ? threeObject.reticulumData.clickCancelFuse : fuse.clickCancel;
         //Cancel Fuse
@@ -460,13 +469,13 @@ var Reticulum = (function () {
             //Force gaze to end...this might be to assumptions
             fuse.update( fuse.duration );
         }
-        
+
         //Does object have an action assigned to it?
         if (threeObject.onGazeClick != null) {
             threeObject.onGazeClick();
         }
     };
-    
+
     //This function is called on click or touch events
     var touchClickHandler = function(e) {
         if( reticle.hit && INTERSECTED ) {
@@ -474,12 +483,12 @@ var Reticulum = (function () {
             gazeClick(INTERSECTED);
         }
     }
-    
-    
+
+
     return {
         add: function (threeObject, options) {
             var parameters = options || {};
-            
+
             //Stores object options for reticulum
             threeObject.reticulumData = {};
             threeObject.reticulumData.gazeable = true;
@@ -498,14 +507,14 @@ var Reticulum = (function () {
             threeObject.onGazeOut                               = parameters.onGazeOut              || null;
             threeObject.onGazeLong                              = parameters.onGazeLong             || null;
             threeObject.onGazeClick                             = parameters.onGazeClick            || null;
-            
+
 
             //Add object to list
             collisionList.push(threeObject);
         },
         remove: function (threeObject) {
             var index = collisionList.indexOf(threeObject);
-             threeObject.reticulumData.gazeable = false;
+            threeObject.reticulumData.gazeable = false;
             if (index > -1) {
                 collisionList.splice(index, 1);
             }
@@ -513,15 +522,15 @@ var Reticulum = (function () {
         update: function () {
             var delta = clock.getDelta(); //
             detectHit();
-            
+
             //Proximity
             if(settings.proximity) {
                 proximity();
             }
-            
+
             //Animation
             reticle.update(delta);
-            
+
         },
         init: function (camera, options) {
             var c = camera || null;


### PR DESCRIPTION
Setting `lockDistance` to `true` allows the reticle to be positioned at the `restPoint` distance always, without moving it to intersect with the gazed object. E.g.

```
Reticulum.init(camera, {
        proximity: false,
        clickevents: true,
        lockDistance: true,
        near: 1400,
        far: 1600,
        reticle: {
            visible: true,
            restPoint: 50,
            color: 0xcc0000,
            innerRadius: 0.005,
            outerRadius: 0.01,
            hover: {
                color: 0xffffff,
                innerRadius: 0.005,
                outerRadius: 0.01,
                speed: 2,
                vibrate: 50
            }
        },
        fuse: {
            visible: true,
            duration: 0.5,
            color: 0xffffff,
            innerRadius: 0.01,
            outerRadius: 0.015,
            vibrate: 100,
            clickCancelFuse: false
        }
    });
```
